### PR TITLE
`PEER` configuration for proxying

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const config = require('./config');
 // Add resources:
 require('./resources/disk')(router);
 require('./resources/environment')(router);
+require('./resources/peer')(router);
 require('./resources/postgres')(router);
 require('./resources/redis')(router);
 require('./resources/root')(router);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,21 @@ services:
     links:
       - redis
       - postgres
+      - peer
     volumes:
       - data:/mnt/data
     environment:
       - DISK_PATH=/mnt/data/file.txt
       - REDIS_URL=redis://redis:6379
       - POSTGRES_URL=postgres://postgres:laika@postgres:5432/postgres
+      - LAIKA_PEER_TEST=http://peer:8080/
     ports:
      - 8080
 
+  peer:
+    build: .
+    environment:
+      - MESSAGE=nested peer
   redis:
     image: redis:3.2-alpine
   postgres:
@@ -30,6 +36,7 @@ services:
       - DISK_PATH=true
       - REDIS_URL=true
       - POSTGRES_URL=true
+      - LAIKA_PEERS=test
     entrypoint: npm test
 
 volumes:

--- a/resources/peer.js
+++ b/resources/peer.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const bluebird = require('bluebird');
+const request = require('superagent');
+bluebird.promisifyAll(request);
+
+module.exports = (router) => {
+  const PEER_CACHE = {};
+
+  /**
+   * Get peer URL.
+   * @param {String} name Peer name.
+   * @returns {String|undefined} Peer URL.
+   */
+  function getPeerUrl(name) {
+    // Normalize name:
+    name = name.toUpperCase();
+
+    // Check cache:
+    const cached = PEER_CACHE[name];
+    if (cached) {
+      return cached;
+    }
+
+    // Load, normalize URL:
+    let peerUrl = process.env[`LAIKA_PEER_${name}`];
+    if (peerUrl && !peerUrl.endsWith('/')) {
+      peerUrl += '/';
+    }
+
+    // Cache and return:
+    PEER_CACHE[name] = peerUrl;
+    return peerUrl;
+  }
+
+  /**
+   * Proxy a response to a configured laika peer.
+   */
+  router.all(/^\/peer\/([^\/]*)\/(.*)/, function* () {
+    // Is there a configured peer with this name?
+    const peerUrl = getPeerUrl(this.params[0]);
+    if (!peerUrl) {
+      return this.throw(404);
+    }
+
+    // Parse command to be executed on peer; only 1 hop is allowed.
+    const peerCommand = this.params[1];
+    if (peerCommand.startsWith('peer')) {
+      return this.throw(400);
+    }
+
+    const response = yield request(request.method, peerUrl + peerCommand);
+    this.body = response.body;
+  });
+};

--- a/test-integration/test-peer.js
+++ b/test-integration/test-peer.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const test = require('./test');
+
+describe('/peer', () => {
+  if (!process.env.LAIKA_PEERS) {
+    return;
+  }
+
+  const peers = process.env.LAIKA_PEERS.split(',');
+
+  describe('/peer', () => {
+    it('returns 404 on missing peer', function* () {
+      yield test()
+        .get('/peer/does-not-exist')
+        .expect(404);
+    });
+  });
+
+  peers.forEach((peerName) => {
+    const peerUrl = `/peer/${peerName}`;
+    describe(peerUrl, () => {
+      it('returns environment', function* () {
+        yield test()
+          .get(`${peerUrl}/environment`)
+          .expect(200)
+          .expect('Content-Type', /json/);
+      });
+
+      it('rejects /peer url', function* () {
+        yield test()
+          .get(`${peerUrl}${peerUrl}/environment`)
+          .expect(400);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This lets existing code be repurposed to verify a laika that isn't
directly accessible (i.e. `elb_availability=(private|multi-region)`).